### PR TITLE
feat: add multi-token support for fine-grained PATs

### DIFF
--- a/env.example
+++ b/env.example
@@ -1,7 +1,14 @@
 # Note: If you have these environment variables set in your own environment, the ones in your environment will take precedence over any you put here.
 
 # GitHub Configuration
+# Option 1: Single token (simplest)
 GITHUB_TOKEN=your_github_token_here
+
+# Option 2: Multiple tokens (for working across multiple projects with fine-grained PATs)
+# Comma-separated list of tokens. When --post is used, each token is tested for write access
+# and the first one that works is used. This is useful if you have separate fine-grained PATs
+# for different repositories. Takes precedence over GITHUB_TOKEN for write operations.
+# REVIEW_ROADMAP_GITHUB_TOKENS=ghp_token1,ghp_token2,ghp_token3
 
 # Application Settings
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,116 @@
+"""Tests for the config module."""
+
+import pytest
+from review_roadmap.config import Settings
+
+
+class TestGetGithubTokens:
+    """Tests for Settings.get_github_tokens method."""
+    
+    def test_get_github_tokens_single_token(self):
+        """Returns single GITHUB_TOKEN when no multi-token configured."""
+        settings = Settings(
+            GITHUB_TOKEN="single-token",
+            REVIEW_ROADMAP_MODEL_NAME="test-model",
+            _env_file=None  # Disable .env file loading
+        )
+        
+        tokens = settings.get_github_tokens()
+        
+        assert tokens == ["single-token"]
+    
+    def test_get_github_tokens_multi_token_precedence(self):
+        """REVIEW_ROADMAP_GITHUB_TOKENS takes precedence over GITHUB_TOKEN."""
+        settings = Settings(
+            GITHUB_TOKEN="fallback-token",
+            REVIEW_ROADMAP_GITHUB_TOKENS="token1,token2,token3",
+            REVIEW_ROADMAP_MODEL_NAME="test-model",
+            _env_file=None
+        )
+        
+        tokens = settings.get_github_tokens()
+        
+        # Multi-tokens should come first, fallback token appended
+        assert tokens == ["token1", "token2", "token3", "fallback-token"]
+    
+    def test_get_github_tokens_strips_whitespace(self):
+        """Whitespace is stripped from comma-separated tokens."""
+        settings = Settings(
+            REVIEW_ROADMAP_GITHUB_TOKENS=" token1 , token2 , token3 ",
+            REVIEW_ROADMAP_MODEL_NAME="test-model",
+            _env_file=None
+        )
+        
+        tokens = settings.get_github_tokens()
+        
+        assert tokens == ["token1", "token2", "token3"]
+    
+    def test_get_github_tokens_no_duplicates(self):
+        """GITHUB_TOKEN is not duplicated if already in REVIEW_ROADMAP_GITHUB_TOKENS."""
+        settings = Settings(
+            GITHUB_TOKEN="token1",
+            REVIEW_ROADMAP_GITHUB_TOKENS="token1,token2",
+            REVIEW_ROADMAP_MODEL_NAME="test-model",
+            _env_file=None
+        )
+        
+        tokens = settings.get_github_tokens()
+        
+        # token1 should not be duplicated
+        assert tokens == ["token1", "token2"]
+    
+    def test_get_github_tokens_skips_empty(self):
+        """Empty tokens from extra commas are skipped."""
+        settings = Settings(
+            REVIEW_ROADMAP_GITHUB_TOKENS="token1,,token2,",
+            REVIEW_ROADMAP_MODEL_NAME="test-model",
+            _env_file=None
+        )
+        
+        tokens = settings.get_github_tokens()
+        
+        assert tokens == ["token1", "token2"]
+
+
+class TestGetDefaultGithubToken:
+    """Tests for Settings.get_default_github_token method."""
+    
+    def test_get_default_github_token_returns_first(self):
+        """Returns the first token from the tokens list."""
+        settings = Settings(
+            REVIEW_ROADMAP_GITHUB_TOKENS="first-token,second-token",
+            REVIEW_ROADMAP_MODEL_NAME="test-model",
+            _env_file=None
+        )
+        
+        token = settings.get_default_github_token()
+        
+        assert token == "first-token"
+    
+    def test_get_default_github_token_uses_github_token_fallback(self):
+        """Falls back to GITHUB_TOKEN when no multi-token configured."""
+        settings = Settings(
+            GITHUB_TOKEN="my-github-token",
+            REVIEW_ROADMAP_MODEL_NAME="test-model",
+            _env_file=None
+        )
+        
+        token = settings.get_default_github_token()
+        
+        assert token == "my-github-token"
+
+
+class TestSettingsValidation:
+    """Tests for Settings validation."""
+    
+    def test_requires_at_least_one_token(self):
+        """Raises error when no GitHub tokens are configured."""
+        with pytest.raises(ValueError) as exc_info:
+            Settings(
+                REVIEW_ROADMAP_MODEL_NAME="test-model",
+                _env_file=None
+                # No GITHUB_TOKEN or REVIEW_ROADMAP_GITHUB_TOKENS
+            )
+        
+        # Should mention needing a token
+        assert "GITHUB_TOKEN" in str(exc_info.value) or "REVIEW_ROADMAP_GITHUB_TOKENS" in str(exc_info.value)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,6 @@
 """Tests for the config module."""
 
+import os
 import pytest
 from review_roadmap.config import Settings
 
@@ -7,8 +8,12 @@ from review_roadmap.config import Settings
 class TestGetGithubTokens:
     """Tests for Settings.get_github_tokens method."""
     
-    def test_get_github_tokens_single_token(self):
+    def test_get_github_tokens_single_token(self, monkeypatch):
         """Returns single GITHUB_TOKEN when no multi-token configured."""
+        # Clear any env vars that might interfere
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        monkeypatch.delenv("REVIEW_ROADMAP_GITHUB_TOKENS", raising=False)
+        
         settings = Settings(
             GITHUB_TOKEN="single-token",
             REVIEW_ROADMAP_MODEL_NAME="test-model",
@@ -19,8 +24,11 @@ class TestGetGithubTokens:
         
         assert tokens == ["single-token"]
     
-    def test_get_github_tokens_multi_token_precedence(self):
+    def test_get_github_tokens_multi_token_precedence(self, monkeypatch):
         """REVIEW_ROADMAP_GITHUB_TOKENS takes precedence over GITHUB_TOKEN."""
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        monkeypatch.delenv("REVIEW_ROADMAP_GITHUB_TOKENS", raising=False)
+        
         settings = Settings(
             GITHUB_TOKEN="fallback-token",
             REVIEW_ROADMAP_GITHUB_TOKENS="token1,token2,token3",
@@ -33,8 +41,11 @@ class TestGetGithubTokens:
         # Multi-tokens should come first, fallback token appended
         assert tokens == ["token1", "token2", "token3", "fallback-token"]
     
-    def test_get_github_tokens_strips_whitespace(self):
+    def test_get_github_tokens_strips_whitespace(self, monkeypatch):
         """Whitespace is stripped from comma-separated tokens."""
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        monkeypatch.delenv("REVIEW_ROADMAP_GITHUB_TOKENS", raising=False)
+        
         settings = Settings(
             REVIEW_ROADMAP_GITHUB_TOKENS=" token1 , token2 , token3 ",
             REVIEW_ROADMAP_MODEL_NAME="test-model",
@@ -45,8 +56,11 @@ class TestGetGithubTokens:
         
         assert tokens == ["token1", "token2", "token3"]
     
-    def test_get_github_tokens_no_duplicates(self):
+    def test_get_github_tokens_no_duplicates(self, monkeypatch):
         """GITHUB_TOKEN is not duplicated if already in REVIEW_ROADMAP_GITHUB_TOKENS."""
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        monkeypatch.delenv("REVIEW_ROADMAP_GITHUB_TOKENS", raising=False)
+        
         settings = Settings(
             GITHUB_TOKEN="token1",
             REVIEW_ROADMAP_GITHUB_TOKENS="token1,token2",
@@ -59,8 +73,11 @@ class TestGetGithubTokens:
         # token1 should not be duplicated
         assert tokens == ["token1", "token2"]
     
-    def test_get_github_tokens_skips_empty(self):
+    def test_get_github_tokens_skips_empty(self, monkeypatch):
         """Empty tokens from extra commas are skipped."""
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        monkeypatch.delenv("REVIEW_ROADMAP_GITHUB_TOKENS", raising=False)
+        
         settings = Settings(
             REVIEW_ROADMAP_GITHUB_TOKENS="token1,,token2,",
             REVIEW_ROADMAP_MODEL_NAME="test-model",
@@ -75,8 +92,11 @@ class TestGetGithubTokens:
 class TestGetDefaultGithubToken:
     """Tests for Settings.get_default_github_token method."""
     
-    def test_get_default_github_token_returns_first(self):
+    def test_get_default_github_token_returns_first(self, monkeypatch):
         """Returns the first token from the tokens list."""
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        monkeypatch.delenv("REVIEW_ROADMAP_GITHUB_TOKENS", raising=False)
+        
         settings = Settings(
             REVIEW_ROADMAP_GITHUB_TOKENS="first-token,second-token",
             REVIEW_ROADMAP_MODEL_NAME="test-model",
@@ -87,8 +107,11 @@ class TestGetDefaultGithubToken:
         
         assert token == "first-token"
     
-    def test_get_default_github_token_uses_github_token_fallback(self):
+    def test_get_default_github_token_uses_github_token_fallback(self, monkeypatch):
         """Falls back to GITHUB_TOKEN when no multi-token configured."""
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        monkeypatch.delenv("REVIEW_ROADMAP_GITHUB_TOKENS", raising=False)
+        
         settings = Settings(
             GITHUB_TOKEN="my-github-token",
             REVIEW_ROADMAP_MODEL_NAME="test-model",
@@ -103,8 +126,12 @@ class TestGetDefaultGithubToken:
 class TestSettingsValidation:
     """Tests for Settings validation."""
     
-    def test_requires_at_least_one_token(self):
+    def test_requires_at_least_one_token(self, monkeypatch):
         """Raises error when no GitHub tokens are configured."""
+        # Must clear env vars so pydantic-settings doesn't pick them up
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        monkeypatch.delenv("REVIEW_ROADMAP_GITHUB_TOKENS", raising=False)
+        
         with pytest.raises(ValueError) as exc_info:
             Settings(
                 REVIEW_ROADMAP_MODEL_NAME="test-model",


### PR DESCRIPTION
## Summary

Add `REVIEW_ROADMAP_GITHUB_TOKENS` environment variable that accepts a comma-separated list of GitHub tokens. When `--post` is used, each token is tested for write access until one with the correct permissions is found.

This is useful when working with multiple repositories that each have their own fine-grained PAT, eliminating the need to change `.env` when switching between projects.

## Changes

- **config.py**: Add `REVIEW_ROADMAP_GITHUB_TOKENS` setting with helper methods (`get_github_tokens()`, `get_default_github_token()`)
- **client.py**: Add `find_working_token()` function to search through tokens for write access
- **main.py**: Use multi-token search when `--post` flag is provided
- **env.example**: Document new environment variable
- **tests**: Add comprehensive tests for new functionality (13 new tests)

## Usage

```bash
# In .env - list multiple fine-grained PATs
REVIEW_ROADMAP_GITHUB_TOKENS=ghp_token_for_repo1,ghp_token_for_repo2,ghp_token_for_repo3
```

When running with `--post`, tokens are tried in order until one with write access is found:

```
$ review_roadmap owner/repo/123 --post
Searching 3 tokens for write access to owner/repo...
Write access confirmed (token 2 of 3).
...
```

## Precedence

- `REVIEW_ROADMAP_GITHUB_TOKENS` takes precedence over `GITHUB_TOKEN` for write operations
- `GITHUB_TOKEN` is appended as a fallback if not already in the list
- At least one token must be configured (either variable)

## Test Results

All 89 tests pass with 84% coverage.